### PR TITLE
fix: `parse_params` and ' m' are note defined

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -2,7 +2,7 @@ var ParseAuth= /(\w+)\s+(.*)/  // -> scheme, params
   , Separators= /([",=])/
   ;
 
-parse_params= function (header) {
+function parse_params(header) {
   // This parser will definitely fail if there is more than one challenge
   var tok, last_tok, _i, _len, key, value;
   var state= 0;   //0: token,

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -6,7 +6,7 @@ function parse_params(header) {
   // This parser will definitely fail if there is more than one challenge
   var tok, last_tok, _i, _len, key, value;
   var state= 0;   //0: token,
-  m= header.split(Separators)
+  var m= header.split(Separators)
   for (_i = 0, _len = m.length; _i < _len; _i++) {
     last_tok= tok;
     tok = m[_i];


### PR DESCRIPTION
That error occures in modern strict node versions